### PR TITLE
Fix TOC parsing due to Volume 1 rewrite

### DIFF
--- a/wanderinginn2epub.py
+++ b/wanderinginn2epub.py
@@ -208,7 +208,7 @@ def get_index(toc_url=r'https://wanderinginn.com/table-of-contents/'):
 
     index = []
     volume = 0
-    for v, chapters in zip(paragraphs[0::2], paragraphs[1::2]):
+    for v, chapters in zip(paragraphs[1::2], paragraphs[2::2]):
         try:
             volume = int(v.text.replace("Volume","").strip())
         except ValueError:


### PR DESCRIPTION
This PR fixes parsing of the [Table of Contents](https://wanderinginn.com/table-of-contents/) that was broken due to the notice at the top notifying readers about the rewrite.

The fix is very simple, it just ignores the first `p` tag. Ideally, a better option would be to ignore all `p` tags until one that starts with `Volume` is found, but this would be a bit harder to implement.