### PR TITLE
Fix 404 errors downloading images

### DIFF
--- a/wanderinginn2epub.py
+++ b/wanderinginn2epub.py
@@ -123,7 +123,7 @@ class Chapter:
                     pass
             if img_filename:
                 with open(os.path.join(image_path, img_filename), 'wb') as fo:
-                    fo.write(urlopen(img['src'], timeout=5, context=ssl.create_default_context()).read())
+                    fo.write(urlopen(img['src'], timeout=10, context=ssl.create_default_context()).read())
                 img['src'] = os.path.join(image_path, img_filename)
             else:
                 print(f'Removing image: unable to determine filename:\n\t{img}')

--- a/wanderinginn2epub.py
+++ b/wanderinginn2epub.py
@@ -11,6 +11,7 @@ import json
 import os
 import sys
 import re
+import ssl
 from copy import deepcopy
 from pprint import pprint
 from urllib.request import URLError, urlopen
@@ -122,7 +123,7 @@ class Chapter:
                     pass
             if img_filename:
                 with open(os.path.join(image_path, img_filename), 'wb') as fo:
-                    fo.write(urlopen(img['src'], timeout=5).read())
+                    fo.write(urlopen(img['src'], timeout=5, context=ssl.create_default_context()).read())
                 img['src'] = os.path.join(image_path, img_filename)
             else:
                 print(f'Removing image: unable to determine filename:\n\t{img}')


### PR DESCRIPTION
This should fix a weird issue that appears on Python 3.9 causing it to return a 404
All it does is configures urllib to use the default SSL context. Not sure if wanderinginn.com is doing TLS fingerprinting, or if it is just a weird TLS configuration thing. I can't properly debug it because using a SSL proxy like Fiddler fixes the issue...
(Fix #20)